### PR TITLE
[Feature] Neo4j 데이터 조회 기능 추가

### DIFF
--- a/src/main/java/com/team7/retriever/neo4j/controller/ArgotController.java
+++ b/src/main/java/com/team7/retriever/neo4j/controller/ArgotController.java
@@ -1,0 +1,30 @@
+package com.team7.retriever.neo4j.controller;
+
+import com.team7.retriever.neo4j.entity.Argot;
+import com.team7.retriever.neo4j.service.ArgotService;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/neo4j/argots")
+@RequiredArgsConstructor
+public class ArgotController {
+
+	private final ArgotService argotService;
+
+	@GetMapping
+	public List<Argot> getAllArgots() {
+		return argotService.getAllArgots();
+	}
+
+	@GetMapping("/depth")
+	public List<Argot> getPostsDepth1() {
+		return argotService.getAllArgotsWithRefersTo();
+	}
+}

--- a/src/main/java/com/team7/retriever/neo4j/controller/ChannelController.java
+++ b/src/main/java/com/team7/retriever/neo4j/controller/ChannelController.java
@@ -1,0 +1,29 @@
+package com.team7.retriever.neo4j.controller;
+
+import com.team7.retriever.neo4j.entity.Channel;
+import com.team7.retriever.neo4j.service.ChannelService;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/neo4j/channels")
+@RequiredArgsConstructor
+public class ChannelController {
+	private final ChannelService channelService;
+
+	@GetMapping
+	public List<Channel> getAllChannels() {
+		return channelService.getAllChannels();
+	}
+
+	@GetMapping("/depth")
+	public List<Channel> getChannelsDepth1() {
+		return channelService.getAllChannelsWithArgots();
+	}
+}

--- a/src/main/java/com/team7/retriever/neo4j/controller/DrugController.java
+++ b/src/main/java/com/team7/retriever/neo4j/controller/DrugController.java
@@ -22,4 +22,5 @@ public class DrugController {
 	public List<Drug> getAllDrugs() {
 		return drugService.getAllDrugs();
 	}
+
 }

--- a/src/main/java/com/team7/retriever/neo4j/controller/DrugController.java
+++ b/src/main/java/com/team7/retriever/neo4j/controller/DrugController.java
@@ -22,5 +22,4 @@ public class DrugController {
 	public List<Drug> getAllDrugs() {
 		return drugService.getAllDrugs();
 	}
-
 }

--- a/src/main/java/com/team7/retriever/neo4j/controller/DrugController.java
+++ b/src/main/java/com/team7/retriever/neo4j/controller/DrugController.java
@@ -1,0 +1,25 @@
+package com.team7.retriever.neo4j.controller;
+
+import com.team7.retriever.neo4j.entity.Drug;
+import com.team7.retriever.neo4j.service.DrugService;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/neo4j/drugs")
+@RequiredArgsConstructor
+public class DrugController {
+
+	private final DrugService drugService;
+
+	@GetMapping
+	public List<Drug> getAllDrugs() {
+		return drugService.getAllDrugs();
+	}
+}

--- a/src/main/java/com/team7/retriever/neo4j/controller/PostController.java
+++ b/src/main/java/com/team7/retriever/neo4j/controller/PostController.java
@@ -1,13 +1,12 @@
 package com.team7.retriever.neo4j.controller;
 
-import com.team7.retriever.neo4j.entity.Posts;
+import com.team7.retriever.neo4j.entity.Post;
 import com.team7.retriever.neo4j.service.PostService;
 
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -18,32 +17,8 @@ import java.util.List;
 public class PostController {
 	private final PostService postService;
 
-    /*
-    // 데이터 많으면 실행 X (드라이버 연결 끊어짐)
-    @GetMapping
-    public List<Posts> getAllPosts() {
-        return postService.getAllPosts();
-    }
-
-    @GetMapping("/depth")
-    public List<Posts> getPostsDepth1() {
-        return postService.getAllPostsDepth1();
-    }
-     */
-
-    /*
-    // paging
-    @GetMapping("/paged")
-    public List<Posts> getPagedPosts(
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "100") int size
-    ) {
-        return postService.getPagedPosts(page, size);
-    }
-     */
-
 	@GetMapping("/streamed")
-	public List<Posts> getAllPostsStreamed() {
+	public List<Post> getAllPostsStreamed() {
 		return postService.getAllPostsStreamed();
 	}
 

--- a/src/main/java/com/team7/retriever/neo4j/controller/PostController.java
+++ b/src/main/java/com/team7/retriever/neo4j/controller/PostController.java
@@ -1,0 +1,50 @@
+package com.team7.retriever.neo4j.controller;
+
+import com.team7.retriever.neo4j.entity.Posts;
+import com.team7.retriever.neo4j.service.PostService;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/neo4j/posts")
+@RequiredArgsConstructor
+public class PostController {
+	private final PostService postService;
+
+    /*
+    // 데이터 많으면 실행 X (드라이버 연결 끊어짐)
+    @GetMapping
+    public List<Posts> getAllPosts() {
+        return postService.getAllPosts();
+    }
+
+    @GetMapping("/depth")
+    public List<Posts> getPostsDepth1() {
+        return postService.getAllPostsDepth1();
+    }
+     */
+
+    /*
+    // paging
+    @GetMapping("/paged")
+    public List<Posts> getPagedPosts(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "100") int size
+    ) {
+        return postService.getPagedPosts(page, size);
+    }
+     */
+
+	@GetMapping("/streamed")
+	public List<Posts> getAllPostsStreamed() {
+		return postService.getAllPostsStreamed();
+	}
+
+}

--- a/src/main/java/com/team7/retriever/neo4j/entity/Argot.java
+++ b/src/main/java/com/team7/retriever/neo4j/entity/Argot.java
@@ -1,8 +1,6 @@
 package com.team7.retriever.neo4j.entity;
 
-import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonManagedReference;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -24,27 +22,8 @@ public class Argot {
 	private String name;
 	private String drugId;
 
-    /*
-    @Relationship(type = "SELLS", direction = Relationship.Direction.INCOMING)
-    @JsonBackReference
-    private Set<Channel> sellingChannels = new HashSet<>();
-
-     */
-
 	@Relationship(type = "REFERS_TO", direction = Relationship.Direction.OUTGOING)
-	// @JsonManagedReference
 	@JsonIgnoreProperties("argots")
 	private Set<Drug> refersDrugs = new HashSet<>();
 
-
-    /*
-    // @Relationship(type = "REFERS_TO", direction = Relationship.Direction.OUTGOING)
-    @Relationship(type = "REFERS_TO")
-    @JsonManagedReference
-    private Set<Drug> refersToDrugs = new HashSet<>();
-
-    @Relationship(type = "SELLS", direction = Relationship.Direction.INCOMING)
-    private Set<Channel> soldByChannels = new HashSet<>();
-
-     */
 }

--- a/src/main/java/com/team7/retriever/neo4j/entity/Argot.java
+++ b/src/main/java/com/team7/retriever/neo4j/entity/Argot.java
@@ -1,0 +1,50 @@
+package com.team7.retriever.neo4j.entity;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import org.springframework.data.neo4j.core.schema.Id;
+import org.springframework.data.neo4j.core.schema.Node;
+import org.springframework.data.neo4j.core.schema.Relationship;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Node("Argot")
+@Getter
+@Setter
+public class Argot {
+	@Id
+	private Long identity;
+
+	private String name;
+	private String drugId;
+
+    /*
+    @Relationship(type = "SELLS", direction = Relationship.Direction.INCOMING)
+    @JsonBackReference
+    private Set<Channel> sellingChannels = new HashSet<>();
+
+     */
+
+	@Relationship(type = "REFERS_TO", direction = Relationship.Direction.OUTGOING)
+	// @JsonManagedReference
+	@JsonIgnoreProperties("argots")
+	private Set<Drug> refersDrugs = new HashSet<>();
+
+
+    /*
+    // @Relationship(type = "REFERS_TO", direction = Relationship.Direction.OUTGOING)
+    @Relationship(type = "REFERS_TO")
+    @JsonManagedReference
+    private Set<Drug> refersToDrugs = new HashSet<>();
+
+    @Relationship(type = "SELLS", direction = Relationship.Direction.INCOMING)
+    private Set<Channel> soldByChannels = new HashSet<>();
+
+     */
+}

--- a/src/main/java/com/team7/retriever/neo4j/entity/Channel.java
+++ b/src/main/java/com/team7/retriever/neo4j/entity/Channel.java
@@ -1,8 +1,6 @@
 package com.team7.retriever.neo4j.entity;
 
-import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonManagedReference;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -24,25 +22,8 @@ public class Channel {
 	private String status;
 	private int promotedCount;
 
-    /*
-    @Relationship(type = "PROMOTES", direction = Relationship.Direction.INCOMING)
-    @JsonBackReference
-    private Set<Promotes> promotedPosts = new HashSet<>();
-
-     */
-
 	@Relationship(type = "SELLS", direction = Relationship.Direction.OUTGOING)
-	// @JsonManagedReference
 	@JsonIgnoreProperties("channels")
 	private Set<Argot> sellsArgots = new HashSet<>();
-
-    /*
-    @Relationship(type = "PROMOTES", direction = Relationship.Direction.INCOMING)
-    private Set<Promotes> promotedPosts = new HashSet<>();
-
-    @Relationship(type = "SELLS", direction = Relationship.Direction.OUTGOING)
-    private Set<Argot> sellsArgots = new HashSet<>();
-
-     */
 
 }

--- a/src/main/java/com/team7/retriever/neo4j/entity/Channel.java
+++ b/src/main/java/com/team7/retriever/neo4j/entity/Channel.java
@@ -1,7 +1,12 @@
 package com.team7.retriever.neo4j.entity;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
+
 import lombok.Getter;
 import lombok.Setter;
+
 import org.springframework.data.neo4j.core.schema.*;
 
 import java.util.HashSet;
@@ -11,10 +16,33 @@ import java.util.Set;
 @Setter
 @Node("Channel")
 public class Channel {
-    @Id
-    private Long id;
+	@Id
+	private Long id;
 
+	private String title;
+	private String username;
+	private String status;
+	private int promotedCount;
+
+    /*
+    @Relationship(type = "PROMOTES", direction = Relationship.Direction.INCOMING)
+    @JsonBackReference
+    private Set<Promotes> promotedPosts = new HashSet<>();
+
+     */
+
+	@Relationship(type = "SELLS", direction = Relationship.Direction.OUTGOING)
+	// @JsonManagedReference
+	@JsonIgnoreProperties("channels")
+	private Set<Argot> sellsArgots = new HashSet<>();
+
+    /*
     @Relationship(type = "PROMOTES", direction = Relationship.Direction.INCOMING)
     private Set<Promotes> promotedPosts = new HashSet<>();
+
+    @Relationship(type = "SELLS", direction = Relationship.Direction.OUTGOING)
+    private Set<Argot> sellsArgots = new HashSet<>();
+
+     */
 
 }

--- a/src/main/java/com/team7/retriever/neo4j/entity/Drug.java
+++ b/src/main/java/com/team7/retriever/neo4j/entity/Drug.java
@@ -1,0 +1,42 @@
+package com.team7.retriever.neo4j.entity;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import org.springframework.data.neo4j.core.schema.Id;
+import org.springframework.data.neo4j.core.schema.Node;
+import org.springframework.data.neo4j.core.schema.Relationship;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Getter
+@Setter
+@Node("Drug")
+public class Drug {
+
+	@Id
+	private String id;
+
+	private String name;
+	private String englishName;
+	private String type;
+
+
+    /*
+    @Relationship(type = "REFERS_TO", direction = Relationship.Direction.INCOMING)
+    @JsonBackReference
+    private Set<Argot> referredByArgots = new HashSet<>();
+
+     */
+
+    /*
+    // @Relationship(type = "REFERS_TO", direction = Relationship.Direction.INCOMING)
+    @Relationship(type = "REFERS_TO", direction = Relationship.Direction.INCOMING)
+    @JsonBackReference
+    private Set<Argot> referredByArgots = new HashSet<>();
+
+     */
+}

--- a/src/main/java/com/team7/retriever/neo4j/entity/Drug.java
+++ b/src/main/java/com/team7/retriever/neo4j/entity/Drug.java
@@ -24,19 +24,4 @@ public class Drug {
 	private String englishName;
 	private String type;
 
-
-    /*
-    @Relationship(type = "REFERS_TO", direction = Relationship.Direction.INCOMING)
-    @JsonBackReference
-    private Set<Argot> referredByArgots = new HashSet<>();
-
-     */
-
-    /*
-    // @Relationship(type = "REFERS_TO", direction = Relationship.Direction.INCOMING)
-    @Relationship(type = "REFERS_TO", direction = Relationship.Direction.INCOMING)
-    @JsonBackReference
-    private Set<Argot> referredByArgots = new HashSet<>();
-
-     */
 }

--- a/src/main/java/com/team7/retriever/neo4j/entity/Post.java
+++ b/src/main/java/com/team7/retriever/neo4j/entity/Post.java
@@ -18,7 +18,7 @@ import java.util.Set;
 @NoArgsConstructor
 @AllArgsConstructor
 @Node("Post")
-public class Posts {
+public class Post {
 
 	@Id
 	private String postId;
@@ -35,22 +35,7 @@ public class Posts {
 	private Set<Promotes> promotesChannels = new HashSet<>();
 
 	@Relationship(type = "SIMILAR", direction = Relationship.Direction.OUTGOING)
-	// @JsonIgnoreProperties("similarPosts") // 직렬화 X // (depth = 1)
 	@JsonIgnoreProperties({"promotesChannels", "similarPosts"})
-	private Set<Posts> similarPosts = new HashSet<>();
-
-	//    @Relationship(type = "SIMILAR", direction = Relationship.Direction.OUTGOING)
-	//    @JsonManagedReference
-	//    private Set<Posts> similarPosts = new HashSet<>();
-
-    /*
-    @Builder.Default
-    @Relationship(type = "PROMOTES", direction = Relationship.Direction.OUTGOING)
-    private Set<Promotes> promotesChannels = new HashSet<>();
-
-    @Relationship(type = "SIMILAR", direction = Relationship.Direction.OUTGOING)
-    private Set<Posts> similarPosts = new HashSet<>();
-
-     */
+	private Set<Post> similarPosts = new HashSet<>();
 
 }

--- a/src/main/java/com/team7/retriever/neo4j/entity/Posts.java
+++ b/src/main/java/com/team7/retriever/neo4j/entity/Posts.java
@@ -1,11 +1,14 @@
 package com.team7.retriever.neo4j.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
+
 import lombok.*;
+
 import org.springframework.data.neo4j.core.schema.Id;
 import org.springframework.data.neo4j.core.schema.Node;
 import org.springframework.data.neo4j.core.schema.Relationship;
 
-import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -17,17 +20,37 @@ import java.util.Set;
 @Node("Post")
 public class Posts {
 
-    @Id
-    private String postId;
-    private Long channelId;
-    private String content;
-    private String link;
-    private String siteName;
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
+	@Id
+	private String postId;
+	private Long channelId;
+	private String content;
+	private String link;
+	private String siteName;
+	private String createdAt;
+	private String updatedAt;
 
+	@Builder.Default
+	@Relationship(type = "PROMOTES", direction = Relationship.Direction.OUTGOING)
+	@JsonManagedReference
+	private Set<Promotes> promotesChannels = new HashSet<>();
+
+	@Relationship(type = "SIMILAR", direction = Relationship.Direction.OUTGOING)
+	// @JsonIgnoreProperties("similarPosts") // 직렬화 X // (depth = 1)
+	@JsonIgnoreProperties({"promotesChannels", "similarPosts"})
+	private Set<Posts> similarPosts = new HashSet<>();
+
+	//    @Relationship(type = "SIMILAR", direction = Relationship.Direction.OUTGOING)
+	//    @JsonManagedReference
+	//    private Set<Posts> similarPosts = new HashSet<>();
+
+    /*
     @Builder.Default
     @Relationship(type = "PROMOTES", direction = Relationship.Direction.OUTGOING)
-    private Set<Promotes> promotedByChannels = new HashSet<>();
+    private Set<Promotes> promotesChannels = new HashSet<>();
+
+    @Relationship(type = "SIMILAR", direction = Relationship.Direction.OUTGOING)
+    private Set<Posts> similarPosts = new HashSet<>();
+
+     */
 
 }

--- a/src/main/java/com/team7/retriever/neo4j/entity/Promotes.java
+++ b/src/main/java/com/team7/retriever/neo4j/entity/Promotes.java
@@ -1,6 +1,7 @@
 package com.team7.retriever.neo4j.entity;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import org.springframework.data.neo4j.core.schema.GeneratedValue;
 import org.springframework.data.neo4j.core.schema.Id;
@@ -8,6 +9,7 @@ import org.springframework.data.neo4j.core.schema.RelationshipProperties;
 import org.springframework.data.neo4j.core.schema.TargetNode;
 
 @Getter
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 @RelationshipProperties
 public class Promotes {
 
@@ -18,19 +20,13 @@ public class Promotes {
 	@TargetNode
 	private Channel channel;
 
-	public Promotes(Channel channel) {
+	private Promotes(Channel channel) {
 		this.channel = channel;
 	}
 
-    /*
-    @TargetNode
-    private Posts post;
-
-    public Promotes(Posts post) {
-        this.post = post;
-    }
-
-     */
+	public static Promotes link(Channel channel) {
+		return new Promotes(channel);
+	}
 
 }
 

--- a/src/main/java/com/team7/retriever/neo4j/entity/Promotes.java
+++ b/src/main/java/com/team7/retriever/neo4j/entity/Promotes.java
@@ -1,6 +1,7 @@
 package com.team7.retriever.neo4j.entity;
 
 import lombok.Getter;
+
 import org.springframework.data.neo4j.core.schema.GeneratedValue;
 import org.springframework.data.neo4j.core.schema.Id;
 import org.springframework.data.neo4j.core.schema.RelationshipProperties;
@@ -10,16 +11,26 @@ import org.springframework.data.neo4j.core.schema.TargetNode;
 @RelationshipProperties
 public class Promotes {
 
-    @Id
-    @GeneratedValue
-    private Long id;
+	@Id
+	@GeneratedValue
+	private Long id;
 
+	@TargetNode
+	private Channel channel;
+
+	public Promotes(Channel channel) {
+		this.channel = channel;
+	}
+
+    /*
     @TargetNode
     private Posts post;
 
     public Promotes(Posts post) {
         this.post = post;
     }
+
+     */
 
 }
 

--- a/src/main/java/com/team7/retriever/neo4j/repository/NeoArgotRepository.java
+++ b/src/main/java/com/team7/retriever/neo4j/repository/NeoArgotRepository.java
@@ -1,0 +1,18 @@
+package com.team7.retriever.neo4j.repository;
+
+import com.team7.retriever.neo4j.entity.Argot;
+
+import org.springframework.data.neo4j.repository.Neo4jRepository;
+import org.springframework.data.neo4j.repository.query.Query;
+
+import java.util.List;
+
+public interface NeoArgotRepository extends Neo4jRepository<Argot, Long> {
+
+	@Query("""
+		    MATCH (a: Argot)
+		    OPTIONAL MATCH (a)-[rf:REFERS_TO]->(d:Drug)
+		    RETURN a, collect(rf), collect(d)
+		""")
+	List<Argot> findAllWithRefersTo();
+}

--- a/src/main/java/com/team7/retriever/neo4j/repository/NeoArgotRepository.java
+++ b/src/main/java/com/team7/retriever/neo4j/repository/NeoArgotRepository.java
@@ -4,9 +4,11 @@ import com.team7.retriever.neo4j.entity.Argot;
 
 import org.springframework.data.neo4j.repository.Neo4jRepository;
 import org.springframework.data.neo4j.repository.query.Query;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
+@Repository
 public interface NeoArgotRepository extends Neo4jRepository<Argot, Long> {
 
 	@Query("""

--- a/src/main/java/com/team7/retriever/neo4j/repository/NeoChannelRepository.java
+++ b/src/main/java/com/team7/retriever/neo4j/repository/NeoChannelRepository.java
@@ -1,14 +1,25 @@
 package com.team7.retriever.neo4j.repository;
 
 import com.team7.retriever.neo4j.entity.Channel;
-import org.springframework.data.neo4j.repository.Neo4jRepository;
 
+import org.springframework.data.neo4j.repository.Neo4jRepository;
+import org.springframework.data.neo4j.repository.query.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
 import java.util.Optional;
 
-
+@Repository
 public interface NeoChannelRepository extends Neo4jRepository<Channel, Long> {
 
-    Optional<Channel> findById(Long channelId);
+	Optional<Channel> findById(Long channelId);
+
+	@Query("""
+		    MATCH (c:Channel)
+		    OPTIONAL MATCH (c)-[sell:SELLS]->(a:Argot)
+		    RETURN c, collect(sell), collect(a)
+		""")
+	List<Channel> findAllWithSells();
 
 }
 

--- a/src/main/java/com/team7/retriever/neo4j/repository/NeoDrugRepository.java
+++ b/src/main/java/com/team7/retriever/neo4j/repository/NeoDrugRepository.java
@@ -3,6 +3,8 @@ package com.team7.retriever.neo4j.repository;
 import com.team7.retriever.neo4j.entity.Drug;
 
 import org.springframework.data.neo4j.repository.Neo4jRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface NeoDrugRepository extends Neo4jRepository<Drug, String> {
 }

--- a/src/main/java/com/team7/retriever/neo4j/repository/NeoDrugRepository.java
+++ b/src/main/java/com/team7/retriever/neo4j/repository/NeoDrugRepository.java
@@ -1,0 +1,8 @@
+package com.team7.retriever.neo4j.repository;
+
+import com.team7.retriever.neo4j.entity.Drug;
+
+import org.springframework.data.neo4j.repository.Neo4jRepository;
+
+public interface NeoDrugRepository extends Neo4jRepository<Drug, String> {
+}

--- a/src/main/java/com/team7/retriever/neo4j/repository/NeoPostsRepository.java
+++ b/src/main/java/com/team7/retriever/neo4j/repository/NeoPostsRepository.java
@@ -1,13 +1,57 @@
 package com.team7.retriever.neo4j.repository;
 
-
 import com.team7.retriever.neo4j.entity.Posts;
+
+import org.springframework.data.neo4j.repository.query.Query;
 import org.springframework.data.neo4j.repository.Neo4jRepository;
 
-import java.util.Optional;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+@Repository
 public interface NeoPostsRepository extends Neo4jRepository<Posts, String> {
 
-    Optional<Posts> findByPostId(String postId);
+	Optional<Posts> findByPostId(String postId);
 
+	/*
+	// paging
+	@Query("""
+		    MATCH (p:Post)
+		    OPTIONAL MATCH (p)-[pr:PROMOTES]->(c:Channel)
+		    OPTIONAL MATCH (p)-[sim:SIMILAR]->(sp:Post)
+		    RETURN p, collect(pr), collect(c), collect(sim), collect(sp)
+		    SKIP $skip LIMIT $limit
+		""")
+	List<Posts> findAllWithPromotesAndSimilarPaged(@Param("skip") long skip, @Param("limit") long limit);
+
+	 */
+
+	// stream
+	@Query("""
+		    MATCH (p:Post)
+		    OPTIONAL MATCH (p)-[pr:PROMOTES]->(c:Channel)
+		    OPTIONAL MATCH (p)-[sim:SIMILAR]->(sp:Post)
+		    RETURN p, collect(pr), collect(c), collect(sim), collect(sp)
+		""")
+	Stream<Posts> streamAllWithPromotesAndSimilar();
+
+	/*
+	// 기존 // 데이터 많으면 실행 X
+	@Query("""
+		    MATCH (p:Post)
+		    OPTIONAL MATCH (p)-[pr:PROMOTES]->(c:Channel)
+		    OPTIONAL MATCH (p)-[sim:SIMILAR]->(sp:Post)
+		    RETURN p, collect(pr), collect(c), collect(sim), collect(sp)
+		""")
+	List<Posts> findAllWithPromotesAndSimilar();
+
+	 */
+
+	// postId 설정
+	@Query("MATCH (p:Post) WHERE p.content = $content SET p.postId = $postId RETURN p")
+	Optional<Posts> updatePostIdByContent(@Param("content") String content, @Param("postId") String postId);
 }

--- a/src/main/java/com/team7/retriever/neo4j/repository/NeoPostsRepository.java
+++ b/src/main/java/com/team7/retriever/neo4j/repository/NeoPostsRepository.java
@@ -1,6 +1,6 @@
 package com.team7.retriever.neo4j.repository;
 
-import com.team7.retriever.neo4j.entity.Posts;
+import com.team7.retriever.neo4j.entity.Post;
 
 import org.springframework.data.neo4j.repository.query.Query;
 import org.springframework.data.neo4j.repository.Neo4jRepository;
@@ -8,27 +8,13 @@ import org.springframework.data.neo4j.repository.Neo4jRepository;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
 @Repository
-public interface NeoPostsRepository extends Neo4jRepository<Posts, String> {
+public interface NeoPostsRepository extends Neo4jRepository<Post, String> {
 
-	Optional<Posts> findByPostId(String postId);
-
-	/*
-	// paging
-	@Query("""
-		    MATCH (p:Post)
-		    OPTIONAL MATCH (p)-[pr:PROMOTES]->(c:Channel)
-		    OPTIONAL MATCH (p)-[sim:SIMILAR]->(sp:Post)
-		    RETURN p, collect(pr), collect(c), collect(sim), collect(sp)
-		    SKIP $skip LIMIT $limit
-		""")
-	List<Posts> findAllWithPromotesAndSimilarPaged(@Param("skip") long skip, @Param("limit") long limit);
-
-	 */
+	Optional<Post> findByPostId(String postId);
 
 	// stream
 	@Query("""
@@ -37,21 +23,10 @@ public interface NeoPostsRepository extends Neo4jRepository<Posts, String> {
 		    OPTIONAL MATCH (p)-[sim:SIMILAR]->(sp:Post)
 		    RETURN p, collect(pr), collect(c), collect(sim), collect(sp)
 		""")
-	Stream<Posts> streamAllWithPromotesAndSimilar();
-
-	/*
-	// 기존 // 데이터 많으면 실행 X
-	@Query("""
-		    MATCH (p:Post)
-		    OPTIONAL MATCH (p)-[pr:PROMOTES]->(c:Channel)
-		    OPTIONAL MATCH (p)-[sim:SIMILAR]->(sp:Post)
-		    RETURN p, collect(pr), collect(c), collect(sim), collect(sp)
-		""")
-	List<Posts> findAllWithPromotesAndSimilar();
-
-	 */
+	Stream<Post> streamAllWithPromotesAndSimilar();
 
 	// postId 설정
 	@Query("MATCH (p:Post) WHERE p.content = $content SET p.postId = $postId RETURN p")
-	Optional<Posts> updatePostIdByContent(@Param("content") String content, @Param("postId") String postId);
+	Optional<Post> updatePostIdByContent(@Param("content") String content, @Param("postId") String postId);
+
 }

--- a/src/main/java/com/team7/retriever/neo4j/service/ArgotService.java
+++ b/src/main/java/com/team7/retriever/neo4j/service/ArgotService.java
@@ -1,0 +1,25 @@
+package com.team7.retriever.neo4j.service;
+
+import com.team7.retriever.neo4j.entity.Argot;
+import com.team7.retriever.neo4j.repository.NeoArgotRepository;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ArgotService {
+
+	private final NeoArgotRepository neoArgotRepository;
+
+	public List<Argot> getAllArgots() {
+		return neoArgotRepository.findAll();
+	}
+
+	public List<Argot> getAllArgotsWithRefersTo() {
+		return neoArgotRepository.findAllWithRefersTo();
+	}
+}

--- a/src/main/java/com/team7/retriever/neo4j/service/ChannelService.java
+++ b/src/main/java/com/team7/retriever/neo4j/service/ChannelService.java
@@ -1,0 +1,28 @@
+package com.team7.retriever.neo4j.service;
+
+import com.team7.retriever.neo4j.entity.Channel;
+import com.team7.retriever.neo4j.repository.NeoChannelRepository;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ChannelService {
+	private final NeoChannelRepository channelRepository;
+
+	public List<Channel> getAllChannels() {
+		Iterable<Channel> iterable = channelRepository.findAll();
+		List<Channel> list = new ArrayList<>();
+		iterable.forEach(list::add);
+		return list;
+	}
+
+	public List<Channel> getAllChannelsWithArgots() {
+		return channelRepository.findAllWithSells();
+	}
+}

--- a/src/main/java/com/team7/retriever/neo4j/service/DrugService.java
+++ b/src/main/java/com/team7/retriever/neo4j/service/DrugService.java
@@ -1,0 +1,21 @@
+package com.team7.retriever.neo4j.service;
+
+import com.team7.retriever.neo4j.entity.Drug;
+import com.team7.retriever.neo4j.repository.NeoDrugRepository;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class DrugService {
+
+	private final NeoDrugRepository neoDrugRepository;
+
+	public List<Drug> getAllDrugs() {
+		return neoDrugRepository.findAll();
+	}
+}

--- a/src/main/java/com/team7/retriever/neo4j/service/PostService.java
+++ b/src/main/java/com/team7/retriever/neo4j/service/PostService.java
@@ -1,0 +1,49 @@
+package com.team7.retriever.neo4j.service;
+
+import com.team7.retriever.neo4j.entity.Posts;
+import com.team7.retriever.neo4j.repository.NeoPostsRepository;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PostService {
+
+	private final NeoPostsRepository postsRepository;
+
+    /*
+    public List<Posts> getAllPosts() {
+        Iterable<Posts> iterable = postsRepository.findAll();
+        List<Posts> list = new ArrayList<>();
+        iterable.forEach(list::add);
+        return list;
+    }
+
+    public List<Posts> getAllPostsDepth1() {
+        return postsRepository.findAllWithPromotesAndSimilar();
+    }
+    */
+
+
+    /*
+    // paging
+    public List<Posts> getPagedPosts(int page, int size) {
+        long skip = (long) page * size;
+        return postsRepository.findAllWithPromotesAndSimilarPaged(skip, size);
+    }
+     */
+
+	// stream
+	public List<Posts> getAllPostsStreamed() {
+		try (var stream = postsRepository.streamAllWithPromotesAndSimilar()) {
+			return stream.collect(Collectors.toList());
+		}
+	}
+
+}

--- a/src/main/java/com/team7/retriever/neo4j/service/PostService.java
+++ b/src/main/java/com/team7/retriever/neo4j/service/PostService.java
@@ -1,13 +1,12 @@
 package com.team7.retriever.neo4j.service;
 
-import com.team7.retriever.neo4j.entity.Posts;
+import com.team7.retriever.neo4j.entity.Post;
 import com.team7.retriever.neo4j.repository.NeoPostsRepository;
 
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -17,30 +16,8 @@ public class PostService {
 
 	private final NeoPostsRepository postsRepository;
 
-    /*
-    public List<Posts> getAllPosts() {
-        Iterable<Posts> iterable = postsRepository.findAll();
-        List<Posts> list = new ArrayList<>();
-        iterable.forEach(list::add);
-        return list;
-    }
-
-    public List<Posts> getAllPostsDepth1() {
-        return postsRepository.findAllWithPromotesAndSimilar();
-    }
-    */
-
-
-    /*
-    // paging
-    public List<Posts> getPagedPosts(int page, int size) {
-        long skip = (long) page * size;
-        return postsRepository.findAllWithPromotesAndSimilarPaged(skip, size);
-    }
-     */
-
 	// stream
-	public List<Posts> getAllPostsStreamed() {
+	public List<Post> getAllPostsStreamed() {
 		try (var stream = postsRepository.streamAllWithPromotesAndSimilar()) {
 			return stream.collect(Collectors.toList());
 		}

--- a/src/main/java/com/team7/retriever/neo4j/service/SavingPromotionService.java
+++ b/src/main/java/com/team7/retriever/neo4j/service/SavingPromotionService.java
@@ -3,8 +3,9 @@ package com.team7.retriever.neo4j.service;
 import com.team7.retriever.neo4j.repository.NeoChannelRepository;
 import com.team7.retriever.neo4j.repository.NeoPostsRepository;
 import com.team7.retriever.neo4j.entity.Channel;
-import com.team7.retriever.neo4j.entity.Posts;
 import com.team7.retriever.neo4j.entity.Promotes;
+import com.team7.retriever.neo4j.entity.Post;
+import com.team7.retriever.entity.Posts;
 import com.team7.retriever.service.PostsService;
 
 import jakarta.transaction.Transactional;
@@ -37,24 +38,26 @@ public class SavingPromotionService {
 				return neoChannelRepository.save(newChannel);
 			});
 
-		Optional<com.team7.retriever.entity.Posts> mongoPostOpt = postsService.getPostById(postId);
-		if (mongoPostOpt.isEmpty()) {
-			log.error("[Neo4j Service] MongoDB에서 해당 Post(" + postId + ")를 찾을 수 없습니다.");
-		}
-		com.team7.retriever.entity.Posts mongoPost = mongoPostOpt.get();
-
 		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
 
+		Optional<Posts> mongoPostOpt = postsService.getPostById(postId);
+		if (mongoPostOpt.isEmpty()) {
+			log.error("[Neo4j Service] MongoDB에서 해당 Post(" + postId + ")를 찾을 수 없습니다.");
+			return;
+		}
+
+		Posts mongoPost = mongoPostOpt.get();
+
 		// 포스트 노드 조회 or 생성
-		Posts post = neoPostsRepository.findByPostId(postId)
+		Post post = neoPostsRepository.findByPostId(postId)
 			.orElseGet(() -> {
-				Posts newPost = Posts.builder()
+				Post newPost = Post.builder()
 					.postId(postId)
 					.channelId(channelId)
 					.content(mongoPost.getContent())
 					.link(mongoPost.getLink())
 					.siteName(mongoPost.getSource() != null ? mongoPost.getSource() : mongoPost.getSiteName())
-					.createdAt(mongoPost.getCreatedAt().format(formatter)) //.format(formatter)
+					.createdAt(mongoPost.getCreatedAt().format(formatter))
 					.updatedAt(mongoPost.getUpdatedAt().format(formatter))
 					.build();
 				log.info("[Neo4j Service] Neo4j에 Post 데이터 생성: postId = " + postId);
@@ -66,7 +69,7 @@ public class SavingPromotionService {
 			.anyMatch(promotes -> promotes.getChannel().getId().equals(channelId));
 
 		if (!alreadyPromoted) {
-			Promotes promotes = new Promotes(channel);
+			Promotes promotes = Promotes.link(channel);
 			post.getPromotesChannels().add(promotes);
 			neoPostsRepository.save(post);  // Post가 관계 주체
 			log.info("[Neo4j Service] 홍보 관계 생성 완료");

--- a/src/main/java/com/team7/retriever/neo4j/service/SavingPromotionService.java
+++ b/src/main/java/com/team7/retriever/neo4j/service/SavingPromotionService.java
@@ -6,11 +6,14 @@ import com.team7.retriever.neo4j.entity.Channel;
 import com.team7.retriever.neo4j.entity.Posts;
 import com.team7.retriever.neo4j.entity.Promotes;
 import com.team7.retriever.service.PostsService;
+
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.stereotype.Service;
 
+import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 
 @Service
@@ -18,44 +21,60 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class SavingPromotionService {
 
-    private final NeoChannelRepository neoChannelRepository;
-    private final NeoPostsRepository neoPostsRepository;
-    private final PostsService postsService;
+	private final NeoChannelRepository neoChannelRepository;
+	private final NeoPostsRepository neoPostsRepository;
+	private final PostsService postsService;
 
-    @Transactional
-    public void createPromotionRelation(Long channelId, String postId) {
-        log.info("[Neo4j Service] channelId: " + channelId);
-        log.info("[Neo4j Service] postId: " + postId);
-        // 채널 노드 조회 or 생성
-        Channel channel = neoChannelRepository.findById(channelId)
-                .orElseGet(() -> {
-                    Channel newChannel = new Channel();
-                    newChannel.setId(channelId);
-                    return neoChannelRepository.save(newChannel);
-                });
+	@Transactional
+	public void createPromotionRelation(Long channelId, String postId) {
+		log.info("[Neo4j Service] channelId: " + channelId);
+		log.info("[Neo4j Service] postId: " + postId);
+		// 채널 노드 조회 or 생성
+		Channel channel = neoChannelRepository.findById(channelId)
+			.orElseGet(() -> {
+				Channel newChannel = new Channel();
+				newChannel.setId(channelId);
+				return neoChannelRepository.save(newChannel);
+			});
 
-        Optional<com.team7.retriever.entity.Posts> mongoPostOpt = postsService.getPostById(postId);
-        if (mongoPostOpt.isEmpty()) {
-            log.error("[Neo4j Service] MongoDB에서 해당 Post(" + postId + ")를 찾을 수 없습니다.");
-        }
-        com.team7.retriever.entity.Posts mongoPost = mongoPostOpt.get();
+		Optional<com.team7.retriever.entity.Posts> mongoPostOpt = postsService.getPostById(postId);
+		if (mongoPostOpt.isEmpty()) {
+			log.error("[Neo4j Service] MongoDB에서 해당 Post(" + postId + ")를 찾을 수 없습니다.");
+		}
+		com.team7.retriever.entity.Posts mongoPost = mongoPostOpt.get();
 
-        // 포스트 노드 조회 or 생성
-        Posts post = neoPostsRepository.findByPostId(postId)
-                .orElseGet(() -> {
-                    Posts newPost = Posts.builder()
-                            .postId(postId)
-                            .channelId(channelId)
-                            .content(mongoPost.getContent())
-                            .link(mongoPost.getLink())
-                            .siteName(mongoPost.getSource() != null ? mongoPost.getSource() : mongoPost.getSiteName())
-                            .createdAt(mongoPost.getCreatedAt())
-                            .updatedAt(mongoPost.getUpdatedAt())
-                            .build();
-                    log.info("[Neo4j Service] Neo4j에 Post 데이터 생성: postId = " + postId);
-                    return neoPostsRepository.save(newPost);
-                });
+		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
 
+		// 포스트 노드 조회 or 생성
+		Posts post = neoPostsRepository.findByPostId(postId)
+			.orElseGet(() -> {
+				Posts newPost = Posts.builder()
+					.postId(postId)
+					.channelId(channelId)
+					.content(mongoPost.getContent())
+					.link(mongoPost.getLink())
+					.siteName(mongoPost.getSource() != null ? mongoPost.getSource() : mongoPost.getSiteName())
+					.createdAt(mongoPost.getCreatedAt().format(formatter)) //.format(formatter)
+					.updatedAt(mongoPost.getUpdatedAt().format(formatter))
+					.build();
+				log.info("[Neo4j Service] Neo4j에 Post 데이터 생성: postId = " + postId);
+				return neoPostsRepository.save(newPost);
+			});
+
+		// 관계 중복 검사
+		boolean alreadyPromoted = post.getPromotesChannels().stream()
+			.anyMatch(promotes -> promotes.getChannel().getId().equals(channelId));
+
+		if (!alreadyPromoted) {
+			Promotes promotes = new Promotes(channel);
+			post.getPromotesChannels().add(promotes);
+			neoPostsRepository.save(post);  // Post가 관계 주체
+			log.info("[Neo4j Service] 홍보 관계 생성 완료");
+		} else {
+			log.info("[Neo4j Service] 이미 관계가 존재합니다");
+		}
+
+        /*
         // 관계 중복 방지 - 관계가 없으면 추가
         boolean alreadyPromoted = channel.getPromotedPosts().stream()
                 .anyMatch(promotes -> promotes.getPost().getPostId().equals(postId));
@@ -70,6 +89,8 @@ public class SavingPromotionService {
             System.out.println("[Neo4j Service] 이미 관계가 존재합니다");
             log.info("[Neo4j Service] 이미 관계가 존재합니다");
         }
-    }
+
+         */
+	}
 
 }


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
- [x] Neo4j Post 데이터 조회 `/neo4j/posts/streamed` (`PROMOTES Channel`, `SIMILAR Post` 까지)
<img width="1405" height="491" alt="image" src="https://github.com/user-attachments/assets/a589826a-51fe-46db-969c-c4e971ce8dd7" />
<img width="1376" height="362" alt="image" src="https://github.com/user-attachments/assets/9a669ffb-346c-4812-8387-a2aea2995cdb" />

<br></br>
- [x] Neo4j Channel 데이터 조회 `/neo4j/channels/depth` (`SELLS Argot` 까지)
<img width="1384" height="431" alt="image" src="https://github.com/user-attachments/assets/cf08ac76-1fe3-4285-b4cc-dca47693cecb" />

<br></br>
- [x] Neo4j Argot 데이터 조회 `/neo4j/argots/depth` (`REFERS_TO` 까지)
<img width="1390" height="326" alt="image" src="https://github.com/user-attachments/assets/ab9549a6-9560-4bec-b8d6-6464f17ddcaa" />

<br></br>
- [x] Neo4j Drug 데이터 조회 `/neo4j/drugs`
<img width="1378" height="307" alt="image" src="https://github.com/user-attachments/assets/ae4d3adf-fc7d-404e-8615-c8e52b3e27bd" />

<br></br>
- [x] Post 노드 날짜 타입 수정
- Neo4j Post 노드의 날짜 데이터가 문자열로 저장되어 있어 `String`으로 처리
- `DateTimeFormatter` 사용하여 포맷 적용


---

## 🔗 관련 이슈
- closes #11 

---

## 💡 추가 사항
- 연관 데이터의 depth를 1로 제한하였습니다.
- 모든 연관 데이터를 반환하는 API가 포함되어있습니다. (`Post` 제외)

